### PR TITLE
Add batch limit for bookmark enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Enrich all JSON files in a directory:
 python bookmark_enricher.py json/ --directory
 ```
 
+Process a limited number of bookmarks:
+```bash
+python bookmark_enricher.py json/ --directory --limit 10
+```
+
 Custom models:
 ```bash
 python bookmark_enricher.py json/ --embedding-model mxbai-embed-large --llm-model mistral:7b

--- a/tests/test_enricher_batch.py
+++ b/tests/test_enricher_batch.py
@@ -1,0 +1,58 @@
+import types
+from contextlib import contextmanager
+from unittest.mock import patch, Mock
+
+import pytest
+
+from bookmark_enricher import BookmarkEnricher
+from core.models import Bookmark
+
+
+@contextmanager
+def no_spinner(*args, **kwargs):
+    yield
+
+
+def _make_stub(bookmark: Bookmark) -> Bookmark:
+    bookmark.description = "desc"
+    bookmark.tags = ["tag"]
+    return bookmark
+
+
+def test_process_bookmarks_limit(mixed_enrichment_bookmarks):
+    enricher = BookmarkEnricher()
+    enricher.vector_store.rebuild_from_bookmarks = Mock(return_value=True)
+
+    with patch("bookmark_enricher.Spinner", no_spinner), patch(
+        "bookmark_enricher.time.sleep"
+    ), patch.object(enricher, "enrich_bookmark", side_effect=_make_stub) as mock_enrich:
+        enricher._process_bookmarks(mixed_enrichment_bookmarks, limit=2)
+
+    assert mock_enrich.call_count == 2
+    assert mixed_enrichment_bookmarks[2].description == "desc"
+    assert mixed_enrichment_bookmarks[3].description == "desc"
+    # Last unenriched bookmark unchanged
+    assert mixed_enrichment_bookmarks[4].description == ""
+
+
+def test_process_directory_limit(mixed_enrichment_bookmarks):
+    enricher = BookmarkEnricher()
+    with patch.object(
+        enricher.loader, "load_from_directory", return_value=mixed_enrichment_bookmarks
+    ), patch.object(
+        enricher.loader, "save_by_source_file", return_value=True
+    ) as mock_save, patch.object(
+        enricher.vector_store, "rebuild_from_bookmarks", return_value=True
+    ), patch(
+        "bookmark_enricher.Spinner", no_spinner
+    ), patch(
+        "bookmark_enricher.time.sleep"
+    ), patch.object(
+        enricher, "enrich_bookmark", side_effect=_make_stub
+    ) as mock_enrich:
+        enricher.process_directory("dummy", limit=1)
+
+    mock_save.assert_called_once()
+    assert mock_enrich.call_count == 1
+    assert mixed_enrichment_bookmarks[2].description == "desc"
+    assert mixed_enrichment_bookmarks[3].description == "Test site"


### PR DESCRIPTION
## Summary
- allow specifying a limit on the number of unenriched bookmarks to process
- expose `--limit/-n` argument on the `bookmark_enricher.py` CLI
- document the new option in the README
- test that only the specified number of bookmarks are enriched

## Testing
- `ruff check .` *(fails: F541, E501, F401)*
- `mypy core/` *(fails: 'bookmarks-local-ai is not a valid Python package name')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f2407de483299880c57a955a246b