### PR TITLE
Fix populate-category suggestions

### DIFF
--- a/bookmark_intelligence.py
+++ b/bookmark_intelligence.py
@@ -755,7 +755,11 @@ def main():
                 base_dir = args.input
             else:
                 base_dir = os.path.dirname(args.input)
-            
+
+            if not intelligence._ensure_indexed():
+                print("Failed to build search index")
+                return
+
             moved = intelligence.category_manager.populate_category_interactive(
                 args.populate_category,
                 intelligence.bookmarks,

--- a/core/category_manager.py
+++ b/core/category_manager.py
@@ -89,18 +89,24 @@ class CategoryManager:
             for similar in search_result.similar_bookmarks:
                 bookmark = similar.bookmark
                 score = similar.similarity_score
-                
+
                 # Skip if already in target category
                 if bookmark.source_file and os.path.basename(bookmark.source_file) == target_filename:
                     continue
-                    
-                # Only include high-confidence matches
+
                 if score >= threshold:
                     candidates.append((bookmark, score))
-                    
                 if len(candidates) >= limit:
                     break
-                    
+
+            # Fallback: if nothing met the threshold, return best matches anyway
+            if not candidates:
+                for similar in search_result.similar_bookmarks[:limit]:
+                    bookmark = similar.bookmark
+                    if bookmark.source_file and os.path.basename(bookmark.source_file) == target_filename:
+                        continue
+                    candidates.append((bookmark, similar.similarity_score))
+
         return candidates
 
     def move_bookmarks_to_category(

--- a/tests/test_category_manager.py
+++ b/tests/test_category_manager.py
@@ -196,6 +196,28 @@ class TestCategoryManagerFindCandidates:
         # Should respect limit of 2
         assert len(candidates) == 2
 
+    def test_find_candidates_fallback_low_scores(
+        self, category_manager, mock_vector_store, sample_bookmarks
+    ):
+        """Ensure low-score results are still returned if none meet the threshold."""
+        mock_similar = [
+            SimilarBookmark(bookmark=sample_bookmarks[0], similarity_score=0.55, content="c1"),
+            SimilarBookmark(bookmark=sample_bookmarks[1], similarity_score=0.50, content="c2"),
+        ]
+        mock_vector_store.search.return_value = SearchResult(
+            query="emacs",
+            similar_bookmarks=mock_similar,
+            total_results=2,
+        )
+
+        candidates = category_manager.find_category_candidates(
+            "emacs", sample_bookmarks, limit=5, threshold=0.85
+        )
+
+        assert len(candidates) == 2
+        assert candidates[0][0] == sample_bookmarks[0]
+        assert candidates[0][1] == 0.55
+
 
 class TestCategoryManagerMoveBookmarks:
     """Test moving bookmarks between categories."""


### PR DESCRIPTION
## Summary
- when searching for population candidates, fall back to low-scoring results if none meet the threshold
- test fallback behaviour

## Testing
- `pytest -q`
- `black . --check` *(fails: would reformat)*
- `ruff check .` *(fails: style violations)*
- `mypy core/` *(fails: invalid package name)*

------
https://chatgpt.com/codex/tasks/task_e_688140ead04883299b55723b642640f6