### PR TITLE
Add category bulk creation support

### DIFF
--- a/bookmark_intelligence.py
+++ b/bookmark_intelligence.py
@@ -186,14 +186,16 @@ class BookmarkIntelligence:
 
         return duplicates
 
-    def is_duplicate(self, new_bookmark: Bookmark, similarity_threshold: float = 0.85) -> Optional[Bookmark]:
+    def is_duplicate(
+        self, new_bookmark: Bookmark, similarity_threshold: float = 0.85
+    ) -> Optional[Bookmark]:
         """
         Check if a single bookmark is a duplicate of existing bookmarks.
-        
+
         Args:
             new_bookmark: Bookmark to check for duplicates
             similarity_threshold: Minimum similarity score to consider duplicates
-            
+
         Returns:
             Existing bookmark if duplicate found, None otherwise
         """
@@ -201,7 +203,7 @@ class BookmarkIntelligence:
         for bookmark in self.bookmarks:
             if bookmark.url and new_bookmark.url and bookmark.url == new_bookmark.url:
                 return bookmark
-                
+
         # Check similar title (fast)
         if new_bookmark.title:
             normalized_new_title = new_bookmark.title.lower().strip()
@@ -210,30 +212,35 @@ class BookmarkIntelligence:
                     normalized_title = bookmark.title.lower().strip()
                     if normalized_new_title == normalized_title:
                         return bookmark
-        
+
         # Check content similarity using vector search (slower but more thorough)
         if self._ensure_indexed() and new_bookmark.description:
             try:
-                search_content = f"{new_bookmark.title} {new_bookmark.description}".strip()
+                search_content = (
+                    f"{new_bookmark.title} {new_bookmark.description}".strip()
+                )
                 if search_content:
                     results = self.vector_store.search(search_content, n_results=3)
-                    
+
                     for result in results:
-                        if result.get('distances') and len(result['distances'][0]) > 0:
+                        if result.get("distances") and len(result["distances"][0]) > 0:
                             # ChromaDB uses distance (lower is more similar)
                             # Convert to similarity score
-                            distance = result['distances'][0][0]
+                            distance = result["distances"][0][0]
                             similarity = 1.0 - distance
-                            
+
                             if similarity >= similarity_threshold:
                                 # Find the matching bookmark
-                                result_id = result['ids'][0][0]
+                                result_id = result["ids"][0][0]
                                 for bookmark in self.bookmarks:
-                                    if bookmark.url == result_id or str(hash(bookmark.url)) == result_id:
+                                    if (
+                                        bookmark.url == result_id
+                                        or str(hash(bookmark.url)) == result_id
+                                    ):
                                         return bookmark
             except Exception as e:
                 logger.warning(f"Vector similarity check failed: {e}")
-        
+
         return None
 
     def analyze_collection(self) -> Dict:
@@ -286,11 +293,11 @@ class BookmarkIntelligence:
     def create_category(self, category_name: str, output_dir: str = None) -> bool:
         """
         Create a new empty category file.
-        
+
         Args:
             category_name: Name of the category (with or without .json extension)
             output_dir: Directory to create the file in (defaults to input_path)
-            
+
         Returns:
             True if successful, False otherwise
         """
@@ -303,7 +310,7 @@ class BookmarkIntelligence:
                     output_dir = os.path.dirname(self.input_path)
             else:
                 output_dir = "."
-        
+
         return self.category_manager.create_category(category_name, output_dir)
 
     def suggest_categorization(
@@ -352,7 +359,9 @@ class BookmarkIntelligence:
     def interactive_mode(self):
         """Run interactive query interface."""
         print("🔍 Bookmark Intelligence - Interactive Mode")
-        print("Commands: search <query>, duplicates, analyze, categorize <url>, create <category>, quit")
+        print(
+            "Commands: search <query>, duplicates, analyze, categorize <url>, create <category>, quit"
+        )
         print("-" * 60)
 
         while True:
@@ -587,16 +596,24 @@ def main():
         "--output-md", help="Write category suggestions to a markdown file"
     )
     parser.add_argument(
-        "--create-category", help="Create a new empty category file (e.g., '3dprinting' creates '3dprinting.json')"
+        "--create-category",
+        help="Create a new empty category file (e.g., '3dprinting' creates '3dprinting.json')",
     )
     parser.add_argument(
-        "--populate-category", help="Find and suggest bookmarks for a specific category (e.g., '3dprinting' or '3dprinting.json')"
+        "--populate-category",
+        help="Find and suggest bookmarks for a specific category (e.g., '3dprinting' or '3dprinting.json')",
     )
     parser.add_argument(
-        "--limit", type=int, default=5, help="Maximum number of suggestions per run (default: 5)"
+        "--limit",
+        type=int,
+        default=5,
+        help="Maximum number of suggestions per run (default: 5)",
     )
     parser.add_argument(
-        "--threshold", type=float, default=0.85, help="Minimum confidence threshold (default: 0.85)"
+        "--threshold",
+        type=float,
+        default=0.85,
+        help="Minimum confidence threshold (default: 0.85)",
     )
 
     args = parser.parse_args()
@@ -739,9 +756,12 @@ def main():
                             output_dir = args.input
                         else:
                             output_dir = os.path.dirname(args.input)
-                    
-                    suggester.create_placeholder_files(suggestions, output_dir)
-                    print(f"Created files in {output_dir}")
+
+                    names = [s.name.lower().replace(" ", "_") for s in suggestions]
+                    created = intelligence.category_manager.create_categories(
+                        names, output_dir
+                    )
+                    print(f"Created {created} files in {output_dir}")
 
         elif args.create_category:
             if intelligence.create_category(args.create_category):
@@ -765,9 +785,9 @@ def main():
                 intelligence.bookmarks,
                 base_dir,
                 limit=args.limit,
-                threshold=args.threshold
+                threshold=args.threshold,
             )
-            
+
             if moved:
                 print(f"\n✓ Successfully populated {args.populate_category} category")
                 # Re-index after moving bookmarks

--- a/core/category_manager.py
+++ b/core/category_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from .bookmark_loader import BookmarkLoader
 from .models import Bookmark
@@ -24,28 +24,28 @@ class CategoryManager:
     def create_category(self, category_name: str, output_dir: str) -> bool:
         """
         Create a new empty category file.
-        
+
         Args:
             category_name: Name of the category (with or without .json extension)
             output_dir: Directory to create the file in
-            
+
         Returns:
             True if successful, False otherwise
         """
         import json
-        
+
         # Ensure .json extension
-        if not category_name.endswith('.json'):
+        if not category_name.endswith(".json"):
             category_name = f"{category_name}.json"
-        
+
         file_path = os.path.join(output_dir, category_name)
-        
+
         if os.path.exists(file_path):
             logger.warning(f"Category file already exists: {file_path}")
             return False
-        
+
         try:
-            with open(file_path, 'w', encoding='utf-8') as f:
+            with open(file_path, "w", encoding="utf-8") as f:
                 json.dump([], f, indent=2, ensure_ascii=False)
             logger.info(f"Created empty category file: {file_path}")
             return True
@@ -53,45 +53,75 @@ class CategoryManager:
             logger.error(f"Error creating category file: {e}")
             return False
 
+    def create_categories(self, category_names: Sequence[str], output_dir: str) -> int:
+        """Create multiple empty category files.
+
+        Args:
+            category_names: Iterable of category names (with or without .json)
+            output_dir: Directory to create files in
+
+        Returns:
+            Number of files successfully created
+        """
+        created = 0
+        os.makedirs(output_dir, exist_ok=True)
+
+        for name in category_names:
+            if self.create_category(name, output_dir):
+                created += 1
+
+        return created
+
     def find_category_candidates(
-        self, 
-        category_name: str, 
+        self,
+        category_name: str,
         bookmarks: List[Bookmark],
-        limit: int = 5, 
-        threshold: float = 0.85
+        limit: int = 5,
+        threshold: float = 0.85,
     ) -> List[Tuple[Bookmark, float]]:
         """
         Find bookmarks that should belong in a specific category.
-        
+
         Args:
             category_name: Name of the category to populate (e.g., "3d-printing")
             bookmarks: List of all bookmarks to search through
             limit: Maximum number of candidates to return
             threshold: Minimum similarity score to consider
-            
+
         Returns:
             List of (bookmark, confidence_score) tuples sorted by confidence
         """
         # Clean category name (remove .json extension if present)
-        clean_name = category_name.replace('.json', '').replace('-', ' ').replace('_', ' ')
-        
+        clean_name = (
+            category_name.replace(".json", "").replace("-", " ").replace("_", " ")
+        )
+
         # Search for bookmarks similar to this category
         with Spinner(f"Finding candidates for '{clean_name}' category..."):
-            search_result = self.vector_store.search(clean_name, n_results=limit * 3)  # Get extra for filtering
-            
+            search_result = self.vector_store.search(
+                clean_name, n_results=limit * 3
+            )  # Get extra for filtering
+
             if not search_result.similar_bookmarks:
                 return []
-            
+
             # Filter by threshold and exclude bookmarks already in target category
-            target_filename = category_name if category_name.endswith('.json') else f"{category_name}.json"
+            target_filename = (
+                category_name
+                if category_name.endswith(".json")
+                else f"{category_name}.json"
+            )
             candidates = []
-            
+
             for similar in search_result.similar_bookmarks:
                 bookmark = similar.bookmark
                 score = similar.similarity_score
 
                 # Skip if already in target category
-                if bookmark.source_file and os.path.basename(bookmark.source_file) == target_filename:
+                if (
+                    bookmark.source_file
+                    and os.path.basename(bookmark.source_file) == target_filename
+                ):
                     continue
 
                 if score >= threshold:
@@ -103,125 +133,146 @@ class CategoryManager:
             if not candidates:
                 for similar in search_result.similar_bookmarks[:limit]:
                     bookmark = similar.bookmark
-                    if bookmark.source_file and os.path.basename(bookmark.source_file) == target_filename:
+                    if (
+                        bookmark.source_file
+                        and os.path.basename(bookmark.source_file) == target_filename
+                    ):
                         continue
                     candidates.append((bookmark, similar.similarity_score))
 
         return candidates
 
     def move_bookmarks_to_category(
-        self, 
-        bookmarks_to_move: List[Bookmark], 
+        self,
+        bookmarks_to_move: List[Bookmark],
         target_category: str,
         bookmarks: List[Bookmark],
-        base_dir: str
+        base_dir: str,
     ) -> bool:
         """
         Move bookmarks to a target category file.
-        
+
         Args:
             bookmarks_to_move: List of bookmarks to move
             target_category: Target category filename (e.g., "3d-printing.json")
             bookmarks: Full list of bookmarks (will be modified)
             base_dir: Base directory where category files are stored
-            
+
         Returns:
             True if successful, False otherwise
         """
         if not bookmarks_to_move:
             return True
-            
+
         # Ensure target category file has .json extension
-        if not target_category.endswith('.json'):
+        if not target_category.endswith(".json"):
             target_category = f"{target_category}.json"
-                
+
         target_path = os.path.join(base_dir, target_category)
-        
+
         try:
             # Load existing bookmarks in target category
             target_bookmarks = []
             if os.path.exists(target_path):
                 target_bookmarks = self.loader.load_from_file(target_path)
-            
+
             # Add new bookmarks to target
             target_bookmarks.extend(bookmarks_to_move)
-            
+
             # Remove bookmarks from their original files and from the main list
             for bookmark in bookmarks_to_move:
                 if bookmark in bookmarks:
                     bookmarks.remove(bookmark)
-            
+
             # Save target category file
             if not self.loader.save_to_file(target_bookmarks, target_path):
                 logger.error(f"Failed to save target category: {target_path}")
                 return False
-                
+
             # Save changes to original files (remove the moved bookmarks)
             if not self.loader.save_by_source_file(bookmarks, base_dir):
                 logger.error("Failed to update source files")
                 return False
-                        
-            logger.info(f"Successfully moved {len(bookmarks_to_move)} bookmarks to {target_category}")
+
+            logger.info(
+                f"Successfully moved {len(bookmarks_to_move)} bookmarks to {target_category}"
+            )
             return True
-            
+
         except Exception as e:
             logger.error(f"Error moving bookmarks: {e}")
             return False
 
     def populate_category_interactive(
-        self, 
-        category_name: str, 
+        self,
+        category_name: str,
         bookmarks: List[Bookmark],
         base_dir: str,
         limit: int = 5,
-        threshold: float = 0.85
+        threshold: float = 0.85,
     ) -> bool:
         """
         Interactively populate a category with user approval.
-        
+
         Args:
             category_name: Name of the category to populate
             bookmarks: List of all bookmarks to search through
-            base_dir: Base directory where category files are stored  
+            base_dir: Base directory where category files are stored
             limit: Maximum candidates to show per session
             threshold: Minimum similarity score to consider
-            
+
         Returns:
             True if any bookmarks were moved, False otherwise
         """
-        candidates = self.find_category_candidates(category_name, bookmarks, limit, threshold)
-        
+        candidates = self.find_category_candidates(
+            category_name, bookmarks, limit, threshold
+        )
+
         if not candidates:
-            print(f"No high-confidence candidates found for '{category_name}' category.")
+            print(
+                f"No high-confidence candidates found for '{category_name}' category."
+            )
             return False
-            
-        print(f"\nFound {len(candidates)} potential matches for '{category_name}' category:\n")
-        
+
+        print(
+            f"\nFound {len(candidates)} potential matches for '{category_name}' category:\n"
+        )
+
         for i, (bookmark, score) in enumerate(candidates, 1):
-            print(f"{i}. [{score:.2f}] \"{bookmark.title}\"")
+            print(f'{i}. [{score:.2f}] "{bookmark.title}"')
             if bookmark.source_file:
                 source_name = os.path.basename(bookmark.source_file)
                 print(f"   From: {source_name}")
             print(f"   URL: {bookmark.url}")
             if bookmark.description:
-                desc = bookmark.description[:100] + "..." if len(bookmark.description) > 100 else bookmark.description
+                desc = (
+                    bookmark.description[:100] + "..."
+                    if len(bookmark.description) > 100
+                    else bookmark.description
+                )
                 print(f"   Description: {desc}")
             print()
-        
+
         # Get user selection
         while True:
-            choice = input("Move bookmarks to category? [y/N/s(elective)]: ").strip().lower()
-            
-            if choice in ['n', '']:
+            choice = (
+                input("Move bookmarks to category? [y/N/s(elective)]: ").strip().lower()
+            )
+
+            if choice in ["n", ""]:
                 return False
-            elif choice == 'y':
+            elif choice == "y":
                 selected_bookmarks = [bookmark for bookmark, _ in candidates]
                 break
-            elif choice == 's':
-                selection = input(f"Select bookmarks to move (1-{len(candidates)}, comma-separated): ").strip()
+            elif choice == "s":
+                selection = input(
+                    f"Select bookmarks to move (1-{len(candidates)}, comma-separated): "
+                ).strip()
                 try:
-                    indices = [int(x.strip()) - 1 for x in selection.split(',')]
-                    selected_bookmarks = [candidates[i][0] for i in indices if 0 <= i < len(candidates)]
+                    indices = [int(x.strip()) - 1 for x in selection.split(",")]
+                    selected_bookmarks = [
+                        candidates[i][0] for i in indices if 0 <= i < len(candidates)
+                    ]
                     if not selected_bookmarks:
                         print("No valid selections made.")
                         continue
@@ -232,9 +283,11 @@ class CategoryManager:
             else:
                 print("Please enter 'y', 'n', or 's'.")
                 continue
-        
+
         # Move the selected bookmarks
-        if self.move_bookmarks_to_category(selected_bookmarks, category_name, bookmarks, base_dir):
+        if self.move_bookmarks_to_category(
+            selected_bookmarks, category_name, bookmarks, base_dir
+        ):
             print(f"✓ Moved {len(selected_bookmarks)} bookmarks to {category_name}")
             return True
         else:

--- a/tests/test_category_manager.py
+++ b/tests/test_category_manager.py
@@ -44,19 +44,19 @@ def sample_bookmarks():
             url="https://example.com/3d-printer",
             title="Best 3D Printers 2024",
             description="Guide to choosing 3D printers",
-            source_file="hardware.json"
+            source_file="hardware.json",
         ),
         Bookmark(
             url="https://example.com/filament",
             title="3D Printing Filament Guide",
             description="Types of 3D printing filaments",
-            source_file="hardware.json"
+            source_file="hardware.json",
         ),
         Bookmark(
             url="https://example.com/python",
             title="Python Tutorial",
             description="Learn Python programming",
-            source_file="development.json"
+            source_file="development.json",
         ),
     ]
 
@@ -67,22 +67,22 @@ class TestCategoryManagerCreateCategory:
     def test_create_category_success(self, category_manager, temp_dir):
         """Test successful category creation."""
         result = category_manager.create_category("test-category", temp_dir)
-        
+
         assert result is True
-        
+
         # Check file was created
-        expected_path = os.path.join(temp_dir, "test-category.json") 
+        expected_path = os.path.join(temp_dir, "test-category.json")
         assert os.path.exists(expected_path)
-        
+
         # Check file contents
-        with open(expected_path, 'r') as f:
+        with open(expected_path, "r") as f:
             content = json.load(f)
         assert content == []
 
     def test_create_category_with_json_extension(self, category_manager, temp_dir):
         """Test category creation when .json extension is provided."""
         result = category_manager.create_category("test-category.json", temp_dir)
-        
+
         assert result is True
         expected_path = os.path.join(temp_dir, "test-category.json")
         assert os.path.exists(expected_path)
@@ -91,9 +91,9 @@ class TestCategoryManagerCreateCategory:
         """Test handling when category file already exists."""
         # Create the file first
         test_file = os.path.join(temp_dir, "existing.json")
-        with open(test_file, 'w') as f:
+        with open(test_file, "w") as f:
             json.dump([], f)
-        
+
         result = category_manager.create_category("existing", temp_dir)
         assert result is False
 
@@ -102,97 +102,144 @@ class TestCategoryManagerCreateCategory:
         result = category_manager.create_category("test", "/invalid/path")
         assert result is False
 
+    def test_create_categories_multiple(self, category_manager, temp_dir):
+        """Create multiple categories at once."""
+        names = ["one", "two"]
+
+        created = category_manager.create_categories(names, temp_dir)
+
+        assert created == 2
+        for name in names:
+            assert os.path.exists(os.path.join(temp_dir, f"{name}.json"))
+
+    def test_create_categories_skip_existing(self, category_manager, temp_dir):
+        """Existing files are skipped."""
+        existing = os.path.join(temp_dir, "exists.json")
+        with open(existing, "w") as f:
+            json.dump([], f)
+
+        created = category_manager.create_categories(["exists", "new"], temp_dir)
+
+        assert created == 1
+        assert os.path.exists(os.path.join(temp_dir, "new.json"))
+
 
 class TestCategoryManagerFindCandidates:
     """Test finding category candidates."""
 
-    def test_find_candidates_success(self, category_manager, mock_vector_store, sample_bookmarks):
+    def test_find_candidates_success(
+        self, category_manager, mock_vector_store, sample_bookmarks
+    ):
         """Test successful candidate finding."""
         # Mock search results
         mock_similar = [
-            SimilarBookmark(bookmark=sample_bookmarks[0], similarity_score=0.9, content="3d printing content"),
-            SimilarBookmark(bookmark=sample_bookmarks[1], similarity_score=0.87, content="filament content"),
-            SimilarBookmark(bookmark=sample_bookmarks[2], similarity_score=0.5, content="python content"),  # Below threshold
+            SimilarBookmark(
+                bookmark=sample_bookmarks[0],
+                similarity_score=0.9,
+                content="3d printing content",
+            ),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[1],
+                similarity_score=0.87,
+                content="filament content",
+            ),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[2],
+                similarity_score=0.5,
+                content="python content",
+            ),  # Below threshold
         ]
         mock_search_result = SearchResult(
-            query="3d printing", 
-            similar_bookmarks=mock_similar,
-            total_results=3
+            query="3d printing", similar_bookmarks=mock_similar, total_results=3
         )
         mock_vector_store.search.return_value = mock_search_result
-        
+
         candidates = category_manager.find_category_candidates(
             "3d-printing", sample_bookmarks, limit=5, threshold=0.85
         )
-        
+
         # Should return 2 candidates above threshold
         assert len(candidates) == 2
         assert candidates[0][0] == sample_bookmarks[0]
         assert candidates[0][1] == 0.9
-        assert candidates[1][0] == sample_bookmarks[1] 
+        assert candidates[1][0] == sample_bookmarks[1]
         assert candidates[1][1] == 0.87
-        
+
         # Verify search was called with cleaned name
         mock_vector_store.search.assert_called_once_with("3d printing", n_results=15)
 
-    def test_find_candidates_exclude_existing_category(self, category_manager, mock_vector_store, sample_bookmarks):
+    def test_find_candidates_exclude_existing_category(
+        self, category_manager, mock_vector_store, sample_bookmarks
+    ):
         """Test that bookmarks already in target category are excluded."""
         # Set one bookmark to already be in the target category
         sample_bookmarks[0].source_file = "3d-printing.json"
-        
+
         mock_similar = [
-            SimilarBookmark(bookmark=sample_bookmarks[0], similarity_score=0.9, content="3d printing content"),  # Should be excluded
-            SimilarBookmark(bookmark=sample_bookmarks[1], similarity_score=0.87, content="filament content"),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[0],
+                similarity_score=0.9,
+                content="3d printing content",
+            ),  # Should be excluded
+            SimilarBookmark(
+                bookmark=sample_bookmarks[1],
+                similarity_score=0.87,
+                content="filament content",
+            ),
         ]
         mock_search_result = SearchResult(
-            query="3d printing",
-            similar_bookmarks=mock_similar,
-            total_results=2
+            query="3d printing", similar_bookmarks=mock_similar, total_results=2
         )
         mock_vector_store.search.return_value = mock_search_result
-        
+
         candidates = category_manager.find_category_candidates(
             "3d-printing", sample_bookmarks, limit=5, threshold=0.85
         )
-        
+
         # Should only return 1 candidate (excluded the one already in category)
         assert len(candidates) == 1
         assert candidates[0][0] == sample_bookmarks[1]
 
-    def test_find_candidates_no_results(self, category_manager, mock_vector_store, sample_bookmarks):
+    def test_find_candidates_no_results(
+        self, category_manager, mock_vector_store, sample_bookmarks
+    ):
         """Test handling when no search results are found."""
         mock_search_result = SearchResult(
-            query="nonexistent",
-            similar_bookmarks=[],
-            total_results=0
+            query="nonexistent", similar_bookmarks=[], total_results=0
         )
         mock_vector_store.search.return_value = mock_search_result
-        
+
         candidates = category_manager.find_category_candidates(
             "nonexistent", sample_bookmarks
         )
-        
+
         assert len(candidates) == 0
 
-    def test_find_candidates_limit_respected(self, category_manager, mock_vector_store, sample_bookmarks):
+    def test_find_candidates_limit_respected(
+        self, category_manager, mock_vector_store, sample_bookmarks
+    ):
         """Test that the limit parameter is respected."""
         # Create many high-scoring candidates
         mock_similar = [
-            SimilarBookmark(bookmark=sample_bookmarks[0], similarity_score=0.95, content="content1"),
-            SimilarBookmark(bookmark=sample_bookmarks[1], similarity_score=0.90, content="content2"),
-            SimilarBookmark(bookmark=sample_bookmarks[2], similarity_score=0.88, content="content3"),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[0], similarity_score=0.95, content="content1"
+            ),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[1], similarity_score=0.90, content="content2"
+            ),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[2], similarity_score=0.88, content="content3"
+            ),
         ]
         mock_search_result = SearchResult(
-            query="test",
-            similar_bookmarks=mock_similar,
-            total_results=3
+            query="test", similar_bookmarks=mock_similar, total_results=3
         )
         mock_vector_store.search.return_value = mock_search_result
-        
+
         candidates = category_manager.find_category_candidates(
             "test", sample_bookmarks, limit=2, threshold=0.85
         )
-        
+
         # Should respect limit of 2
         assert len(candidates) == 2
 
@@ -201,8 +248,12 @@ class TestCategoryManagerFindCandidates:
     ):
         """Ensure low-score results are still returned if none meet the threshold."""
         mock_similar = [
-            SimilarBookmark(bookmark=sample_bookmarks[0], similarity_score=0.55, content="c1"),
-            SimilarBookmark(bookmark=sample_bookmarks[1], similarity_score=0.50, content="c2"),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[0], similarity_score=0.55, content="c1"
+            ),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[1], similarity_score=0.50, content="c2"
+            ),
         ]
         mock_vector_store.search.return_value = SearchResult(
             query="emacs",
@@ -222,94 +273,113 @@ class TestCategoryManagerFindCandidates:
 class TestCategoryManagerMoveBookmarks:
     """Test moving bookmarks between categories."""
 
-    def test_move_bookmarks_success(self, category_manager, mock_loader, temp_dir, sample_bookmarks):
+    def test_move_bookmarks_success(
+        self, category_manager, mock_loader, temp_dir, sample_bookmarks
+    ):
         """Test successful bookmark moving."""
         # Setup mocks - target category doesn't exist yet
         mock_loader.load_from_file.return_value = []
         mock_loader.save_to_file.return_value = True
         mock_loader.save_by_source_file.return_value = True
-        
+
         bookmarks_to_move = [sample_bookmarks[0]]
         all_bookmarks = sample_bookmarks.copy()
-        
+
         result = category_manager.move_bookmarks_to_category(
             bookmarks_to_move, "3d-printing", all_bookmarks, temp_dir
         )
-        
+
         assert result is True
-        
+
         # Verify bookmark was removed from main list
         assert sample_bookmarks[0] not in all_bookmarks
-        
+
         # Verify save methods were called
         expected_target_path = os.path.join(temp_dir, "3d-printing.json")
-        mock_loader.save_to_file.assert_called_once_with([sample_bookmarks[0]], expected_target_path)
+        mock_loader.save_to_file.assert_called_once_with(
+            [sample_bookmarks[0]], expected_target_path
+        )
         mock_loader.save_by_source_file.assert_called_once_with(all_bookmarks, temp_dir)
 
-    def test_move_bookmarks_existing_target_category(self, category_manager, mock_loader, temp_dir, sample_bookmarks):
+    def test_move_bookmarks_existing_target_category(
+        self, category_manager, mock_loader, temp_dir, sample_bookmarks
+    ):
         """Test moving bookmarks to existing category file."""
         # Setup - target category already has bookmarks
-        existing_bookmark = Bookmark(url="https://existing.com", title="Existing", description="")
+        existing_bookmark = Bookmark(
+            url="https://existing.com", title="Existing", description=""
+        )
         expected_target_path = os.path.join(temp_dir, "3d-printing.json")
-        
+
         # Mock that the target file exists and has existing bookmarks
-        with patch('os.path.exists') as mock_exists:
+        with patch("os.path.exists") as mock_exists:
             mock_exists.return_value = True
             mock_loader.load_from_file.return_value = [existing_bookmark]
             mock_loader.save_to_file.return_value = True
             mock_loader.save_by_source_file.return_value = True
-            
+
             bookmarks_to_move = [sample_bookmarks[0]]
             all_bookmarks = sample_bookmarks.copy()
-            
+
             result = category_manager.move_bookmarks_to_category(
                 bookmarks_to_move, "3d-printing", all_bookmarks, temp_dir
             )
-            
+
             assert result is True
-            
+
             # Verify both existing and new bookmarks were saved
             expected_target_bookmarks = [existing_bookmark, sample_bookmarks[0]]
-            mock_loader.save_to_file.assert_called_once_with(expected_target_bookmarks, expected_target_path)
+            mock_loader.save_to_file.assert_called_once_with(
+                expected_target_bookmarks, expected_target_path
+            )
 
-    def test_move_bookmarks_add_json_extension(self, category_manager, mock_loader, temp_dir, sample_bookmarks):
+    def test_move_bookmarks_add_json_extension(
+        self, category_manager, mock_loader, temp_dir, sample_bookmarks
+    ):
         """Test that .json extension is added if missing."""
         mock_loader.load_from_file.return_value = []
         mock_loader.save_to_file.return_value = True
         mock_loader.save_by_source_file.return_value = True
-        
+
         # Use the specific bookmark for this test
         bookmarks_to_move = [sample_bookmarks[1]]  # The filament bookmark
         all_bookmarks = sample_bookmarks.copy()
-        
+
         result = category_manager.move_bookmarks_to_category(
-            bookmarks_to_move, "3d-printing", all_bookmarks, temp_dir  # No .json extension
+            bookmarks_to_move,
+            "3d-printing",
+            all_bookmarks,
+            temp_dir,  # No .json extension
         )
-        
+
         assert result is True
-        
+
         # Verify .json was added to the path
         expected_target_path = os.path.join(temp_dir, "3d-printing.json")
-        mock_loader.save_to_file.assert_called_once_with(bookmarks_to_move, expected_target_path)
+        mock_loader.save_to_file.assert_called_once_with(
+            bookmarks_to_move, expected_target_path
+        )
 
     def test_move_bookmarks_empty_list(self, category_manager, mock_loader, temp_dir):
         """Test moving empty list of bookmarks."""
         result = category_manager.move_bookmarks_to_category([], "test", [], temp_dir)
-        
+
         assert result is True
         # No mock methods should be called
         mock_loader.save_to_file.assert_not_called()
         mock_loader.save_by_source_file.assert_not_called()
 
-    def test_move_bookmarks_save_failure(self, category_manager, mock_loader, temp_dir, sample_bookmarks):
+    def test_move_bookmarks_save_failure(
+        self, category_manager, mock_loader, temp_dir, sample_bookmarks
+    ):
         """Test handling when saving fails."""
         mock_loader.load_from_file.return_value = []
         mock_loader.save_to_file.return_value = False  # Simulate save failure
-        
+
         result = category_manager.move_bookmarks_to_category(
             [sample_bookmarks[0]], "test", sample_bookmarks, temp_dir
         )
-        
+
         assert result is False
 
 
@@ -324,67 +394,69 @@ class TestCategoryManagerIntegration:
             {
                 "url": "https://example.com/3d-printer",
                 "title": "Best 3D Printers",
-                "description": "Guide to 3D printers"
+                "description": "Guide to 3D printers",
             },
             {
-                "url": "https://example.com/regular-hardware", 
+                "url": "https://example.com/regular-hardware",
                 "title": "Computer Parts",
-                "description": "PC building guide"
-            }
+                "description": "PC building guide",
+            },
         ]
-        
+
         hardware_file = os.path.join(temp_dir, "hardware.json")
-        with open(hardware_file, 'w') as f:
+        with open(hardware_file, "w") as f:
             json.dump(hardware_bookmarks, f, indent=2)
-        
+
         # Create CategoryManager with real dependencies
         from core.bookmark_loader import BookmarkLoader
         from core.vector_store import VectorStore
-        
+
         # Mock just the vector store for this test
         mock_vector_store = Mock()
         loader = BookmarkLoader()
         manager = CategoryManager(mock_vector_store, loader)
-        
+
         # Test 1: Create new category
         result = manager.create_category("3d-printing", temp_dir)
         assert result is True
-        
+
         category_file = os.path.join(temp_dir, "3d-printing.json")
         assert os.path.exists(category_file)
-        
+
         # Test 2: Load bookmarks
         bookmarks = loader.load_from_file(hardware_file)
         assert len(bookmarks) == 2
-        
+
         # Test 3: Mock finding candidates (since we don't have real vector search)
         mock_similar = [
-            SimilarBookmark(bookmark=bookmarks[0], similarity_score=0.9, content="3d printer content")  # The 3D printer bookmark
+            SimilarBookmark(
+                bookmark=bookmarks[0],
+                similarity_score=0.9,
+                content="3d printer content",
+            )  # The 3D printer bookmark
         ]
         mock_search_result = SearchResult(
-            query="3d printing",
-            similar_bookmarks=mock_similar,
-            total_results=1
+            query="3d printing", similar_bookmarks=mock_similar, total_results=1
         )
         mock_vector_store.search.return_value = mock_search_result
-        
+
         candidates = manager.find_category_candidates("3d-printing", bookmarks)
         assert len(candidates) == 1
         assert "3D Printers" in candidates[0][0].title
-        
+
         # Test 4: Move bookmark
         result = manager.move_bookmarks_to_category(
             [candidates[0][0]], "3d-printing", bookmarks, temp_dir
         )
         assert result is True
-        
+
         # Verify files were updated
-        with open(category_file, 'r') as f:
+        with open(category_file, "r") as f:
             category_content = json.load(f)
         assert len(category_content) == 1
         assert category_content[0]["title"] == "Best 3D Printers"
-        
-        with open(hardware_file, 'r') as f:
+
+        with open(hardware_file, "r") as f:
             hardware_content = json.load(f)
         assert len(hardware_content) == 1  # One bookmark moved out
         assert hardware_content[0]["title"] == "Computer Parts"
@@ -393,29 +465,31 @@ class TestCategoryManagerIntegration:
 @pytest.mark.slow
 class TestCategoryManagerInteractive:
     """Test interactive functionality (requires manual input simulation)."""
-    
-    def test_populate_category_interactive_mock_input(self, category_manager, mock_vector_store, sample_bookmarks, temp_dir):
+
+    def test_populate_category_interactive_mock_input(
+        self, category_manager, mock_vector_store, sample_bookmarks, temp_dir
+    ):
         """Test interactive population with mocked user input."""
         # Setup search results
         mock_similar = [
-            SimilarBookmark(bookmark=sample_bookmarks[0], similarity_score=0.9, content="3d content"),
+            SimilarBookmark(
+                bookmark=sample_bookmarks[0], similarity_score=0.9, content="3d content"
+            ),
         ]
         mock_search_result = SearchResult(
-            query="3d printing",
-            similar_bookmarks=mock_similar,
-            total_results=1
+            query="3d printing", similar_bookmarks=mock_similar, total_results=1
         )
         mock_vector_store.search.return_value = mock_search_result
-        
-        # Mock loader for move operation  
+
+        # Mock loader for move operation
         category_manager.loader.load_from_file.return_value = []
         category_manager.loader.save_to_file.return_value = True
         category_manager.loader.save_by_source_file.return_value = True
-        
+
         # Mock user input - select 'y' (yes to move all)
-        with patch('builtins.input', return_value='y'):
+        with patch("builtins.input", return_value="y"):
             result = category_manager.populate_category_interactive(
                 "3d-printing", sample_bookmarks, temp_dir
             )
-        
+
         assert result is True


### PR DESCRIPTION
## Summary
- add `create_categories` to `CategoryManager` for batch file creation
- remove `CategorySuggester.create_placeholder_files`
- call the new manager method from the `--suggest-categories` flow
- test multi-category creation logic

## Testing
- `pytest -q`
- `black . --check` *(fails: would reformat several files)*
- `ruff check bookmark_intelligence.py core/category_manager.py core/category_suggester.py tests/test_category_manager.py` *(fails: E501 and F541 errors in existing code)*
- `mypy core/` *(fails: "bookmarks-local-ai is not a valid Python package name")*

------
https://chatgpt.com/codex/tasks/task_e_6881543816e48329ac4f1e4c41712957