### PR TITLE
Add env setup utility and refactor CLI

### DIFF
--- a/bookmark_enricher.py
+++ b/bookmark_enricher.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """Bookmark Enricher CLI."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
+
+from core.env_setup import configure_chromadb_env
+
+configure_chromadb_env()
 
 import argparse
 import logging
@@ -13,8 +19,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("ollama").setLevel(logging.WARNING)
-logging.getLogger("chromadb.telemetry.posthog").setLevel(logging.CRITICAL)
-logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
 
 
 def main() -> None:

--- a/bookmark_importer.py
+++ b/bookmark_importer.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """Bookmark importer CLI."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
+
+from core.env_setup import configure_chromadb_env
+
+configure_chromadb_env()
 
 import argparse
 

--- a/bookmark_intelligence.py
+++ b/bookmark_intelligence.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """Bookmark Intelligence CLI."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
+
+from core.env_setup import configure_chromadb_env
+
+configure_chromadb_env()
 
 import argparse
 import logging
@@ -16,8 +22,6 @@ from core.category_suggester import CategorySuggester
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
-logging.getLogger("chromadb.telemetry.posthog").setLevel(logging.CRITICAL)
-logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
 
 
 def main() -> None:

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from typing import List, Optional
 
@@ -18,19 +17,11 @@ from .vector_store import VectorStore
 from .web_extractor import WebExtractor
 from .spinner import Spinner
 
-# Disable ChromaDB telemetry
-os.environ["ANONYMIZED_TELEMETRY"] = "False"
-os.environ["CHROMA_SERVER_NOFILE"] = "1"
-
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("ollama").setLevel(logging.WARNING)
-
-# Disable ChromaDB telemetry noise
-logging.getLogger("chromadb.telemetry.posthog").setLevel(logging.CRITICAL)
-logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
 
 
 class ProcessingSummary:

--- a/core/env_setup.py
+++ b/core/env_setup.py
@@ -1,0 +1,14 @@
+"""Environment setup utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+
+def configure_chromadb_env() -> None:
+    """Configure environment variables and logging for ChromaDB."""
+    os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
+    os.environ.setdefault("CHROMA_SERVER_NOFILE", "1")
+    logging.getLogger("chromadb.telemetry.posthog").setLevel(logging.CRITICAL)
+    logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)

--- a/core/intelligence.py
+++ b/core/intelligence.py
@@ -19,12 +19,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
-# Disable ChromaDB telemetry noise
-os.environ["ANONYMIZED_TELEMETRY"] = "False"
-os.environ["CHROMA_SERVER_NOFILE"] = "1"
-logging.getLogger("chromadb.telemetry.posthog").setLevel(logging.CRITICAL)
-logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
-
 
 class BookmarkIntelligence:
     """Smart analysis and search for bookmark collections."""


### PR DESCRIPTION
## Summary
- centralize environment setup in new `core/env_setup.py`
- import and call `configure_chromadb_env()` from all CLI entry points
- remove duplicate environment configuration from `core` modules

## Testing
- `black bookmark_enricher.py bookmark_importer.py bookmark_intelligence.py core/enricher.py core/intelligence.py core/env_setup.py`
- `ruff check bookmark_enricher.py bookmark_importer.py bookmark_intelligence.py core/enricher.py core/intelligence.py core/env_setup.py`
- `mypy core/` *(fails: `bookmarks-local-ai is not a valid Python package name`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881644d10908329a303b73f5dc4a5c6