### PR TITLE
Add CSV support for bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ A local RAG-powered system for enriching and analyzing bookmark collections usin
 Enrich bookmarks in a single file:
 ```bash
 python bookmark_enricher.py bookmarks.json
+# Use a .csv extension to save results in Raindrop CSV format
+python bookmark_enricher.py bookmarks.json --output enriched.csv
 ```
 
 Enrich all JSON files in a directory:
@@ -136,6 +138,8 @@ python bookmark_intelligence.py json/ --populate-category "web-development" --li
 python bookmark_importer.py json/ new_bookmarks.json
 # Or import from browser HTML/Markdown/plain text
 python bookmark_importer.py json/ exported_bookmarks.html
+# Or import from a Raindrop.io CSV export
+python bookmark_importer.py json/ exported_bookmarks.csv
 
 # Skip duplicate checking for faster import (not recommended)
 python bookmark_importer.py json/ new_bookmarks.json --no-duplicate-check
@@ -202,6 +206,10 @@ The system supports flexible bookmark formats:
   }
 ]
 ```
+
+CSV files exported from Raindrop.io are also supported. The columns should be
+`link`, `title`, `excerpt`, `tags`, and `type`. Any CLI command will read or
+write in this format automatically when the path ends with `.csv`.
 
 ## Development
 

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -335,7 +335,8 @@ class BookmarkEnricher:
         self._process_bookmarks(bookmarks, limit=limit)
 
         if output_file is None:
-            output_file = input_file.replace(".json", "_enriched.json")
+            base, ext = os.path.splitext(input_file)
+            output_file = f"{base}_enriched{ext if ext else '.json'}"
 
         if self.loader.save_to_file(bookmarks, output_file):
             logger.info(f"Results saved to {output_file}")

--- a/core/importer.py
+++ b/core/importer.py
@@ -26,6 +26,8 @@ class BookmarkImporter:
 
     def _parse_new_bookmarks(self, file_path: str) -> List[Bookmark]:
         """Parse bookmarks from various supported formats."""
+        if file_path.endswith(".csv"):
+            return BookmarkLoader.load_from_raindrop_csv(file_path)
         with open(file_path, "r", encoding="utf-8") as f:
             raw = f.read()
 
@@ -68,7 +70,7 @@ class BookmarkImporter:
     def import_from_file(
         self, new_bookmarks_file: str, check_duplicates: bool = True
     ) -> tuple[List[str], List[str]]:
-        """Import bookmarks from JSON, HTML, Markdown, or plain URL files."""
+        """Import bookmarks from JSON, HTML, Markdown, CSV, or plain URL files."""
         bookmarks = self._parse_new_bookmarks(new_bookmarks_file)
 
         dead_links: List[str] = []


### PR DESCRIPTION
## Summary
- support Raindrop.io CSV import/export in `BookmarkLoader`
- read CSV in `BookmarkImporter`
- default enriched file naming keeps extension
- document CSV usage in README
- test CSV loading, saving and importing

## Testing
- `ruff check .`
- `mypy core`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829e6582048329a9eb34e41d121dd2