### PR TITLE
Change CSV format defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ A local RAG-powered system for enriching and analyzing bookmark collections usin
 Enrich bookmarks in a single file:
 ```bash
 python bookmark_enricher.py bookmarks.json
-# Use a .csv extension to save results in Raindrop CSV format
+# Results are saved as CSV by default
 python bookmark_enricher.py bookmarks.json --output enriched.csv
+# Save as JSON
+python bookmark_enricher.py bookmarks.json --format json
 ```
 
 Enrich all JSON files in a directory:
@@ -208,8 +210,10 @@ The system supports flexible bookmark formats:
 ```
 
 CSV files exported from Raindrop.io are also supported. The columns should be
-`link`, `title`, `excerpt`, `tags`, and `type`. Any CLI command will read or
-write in this format automatically when the path ends with `.csv`.
+`title`, `note`, `excerpt`, `url`, `folder`, `tags`, `created`, `highlights`, and
+`favorite`. Any CLI command will read or write in this format automatically when
+the path ends with `.csv`. CSV is the default output format; use
+`--format json` to produce JSON instead.
 
 ## Development
 

--- a/bookmark_enricher.py
+++ b/bookmark_enricher.py
@@ -28,7 +28,15 @@ def main() -> None:
         "input", help="Input JSON file or directory with bookmark files"
     )
     parser.add_argument(
-        "--output", "-o", help="Output JSON file (only used for single file mode)"
+        "--output",
+        "-o",
+        help="Output file for single file mode",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["csv", "json"],
+        default="csv",
+        help="Output format when --output is not provided (default: csv)",
     )
     parser.add_argument(
         "--embedding-model",
@@ -72,7 +80,12 @@ def main() -> None:
         if args.directory or os.path.isdir(args.input):
             enricher.process_directory(args.input, limit=args.limit)
         else:
-            enricher.process_single_file(args.input, args.output, limit=args.limit)
+            enricher.process_single_file(
+                args.input,
+                args.output,
+                limit=args.limit,
+                output_format=args.format,
+            )
     except KeyboardInterrupt:
         logger.info("Processing interrupted by user")
     except Exception as e:  # noqa: BLE001

--- a/core/bookmark_loader.py
+++ b/core/bookmark_loader.py
@@ -56,11 +56,13 @@ class BookmarkLoader:
                 reader = csv.DictReader(f)
                 filename = os.path.basename(file_path)
                 for row in reader:
-                    url = row.get("link") or row.get("url") or ""
+                    url = row.get("url") or row.get("link") or ""
                     if not url:
                         continue
                     title = row.get("title", "")
-                    description = row.get("excerpt", "") or row.get("description", "")
+                    note = row.get("note", "")
+                    excerpt = row.get("excerpt", "")
+                    description = note or row.get("description", "") or excerpt
                     tags = [
                         t.strip() for t in row.get("tags", "").split(",") if t.strip()
                     ]
@@ -68,6 +70,7 @@ class BookmarkLoader:
                         url=url,
                         title=title,
                         description=description,
+                        excerpt=excerpt,
                         tags=tags,
                         bookmark_type=row.get("type", "link"),
                     )
@@ -151,7 +154,17 @@ class BookmarkLoader:
     @staticmethod
     def save_to_raindrop_csv(bookmarks: List[Bookmark], file_path: str) -> bool:
         """Save bookmarks to a Raindrop.io compatible CSV file."""
-        fieldnames = ["link", "title", "excerpt", "tags", "type"]
+        fieldnames = [
+            "title",
+            "note",
+            "excerpt",
+            "url",
+            "folder",
+            "tags",
+            "created",
+            "highlights",
+            "favorite",
+        ]
         try:
             with open(file_path, "w", newline="", encoding="utf-8") as f:
                 writer = csv.DictWriter(f, fieldnames=fieldnames)
@@ -159,11 +172,15 @@ class BookmarkLoader:
                 for bm in bookmarks:
                     writer.writerow(
                         {
-                            "link": bm.url,
                             "title": bm.title,
-                            "excerpt": bm.description or bm.excerpt,
+                            "note": bm.description,
+                            "excerpt": bm.excerpt,
+                            "url": bm.url,
+                            "folder": "",
                             "tags": ",".join(bm.tags),
-                            "type": bm.bookmark_type,
+                            "created": "",
+                            "highlights": "",
+                            "favorite": "",
                         }
                     )
             logger.info(f"Saved {len(bookmarks)} bookmarks to {file_path}")

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from typing import List, Optional
 
@@ -322,6 +323,7 @@ class BookmarkEnricher:
         input_file: str,
         output_file: Optional[str] = None,
         limit: Optional[int] = None,
+        output_format: str = "csv",
     ) -> None:
         """Process bookmarks from a single file."""
         logger.info(f"Processing single file: {input_file}")
@@ -335,8 +337,9 @@ class BookmarkEnricher:
         self._process_bookmarks(bookmarks, limit=limit)
 
         if output_file is None:
-            base, ext = os.path.splitext(input_file)
-            output_file = f"{base}_enriched{ext if ext else '.json'}"
+            base, _ = os.path.splitext(input_file)
+            ext = ".csv" if output_format == "csv" else ".json"
+            output_file = f"{base}_enriched{ext}"
 
         if self.loader.save_to_file(bookmarks, output_file):
             logger.info(f"Results saved to {output_file}")

--- a/tests/test_bookmark_importer.py
+++ b/tests/test_bookmark_importer.py
@@ -37,8 +37,32 @@ def create_csv_file(tmp_path, url):
     file_path = tmp_path / "new.csv"
     with open(file_path, "w", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["link", "title"])
-        writer.writerow([url, "Example"])
+        writer.writerow(
+            [
+                "title",
+                "note",
+                "excerpt",
+                "url",
+                "folder",
+                "tags",
+                "created",
+                "highlights",
+                "favorite",
+            ]
+        )
+        writer.writerow(
+            [
+                "Example",
+                "",
+                "",
+                url,
+                "",
+                "",
+                "",
+                "",
+                "",
+            ]
+        )
     return file_path
 
 

--- a/tests/test_bookmark_loader.py
+++ b/tests/test_bookmark_loader.py
@@ -17,15 +17,31 @@ def temp_csv_file(sample_bookmarks):
         mode="w", suffix=".csv", delete=False, newline=""
     ) as f:
         writer = csv.writer(f)
-        writer.writerow(["link", "title", "excerpt", "tags", "type"])
+        writer.writerow(
+            [
+                "title",
+                "note",
+                "excerpt",
+                "url",
+                "folder",
+                "tags",
+                "created",
+                "highlights",
+                "favorite",
+            ]
+        )
         for b in sample_bookmarks:
             writer.writerow(
                 [
-                    b.url,
                     b.title,
-                    b.description or b.excerpt,
+                    b.description,
+                    b.excerpt,
+                    b.url,
+                    "",
                     ",".join(b.tags),
-                    b.bookmark_type,
+                    "",
+                    "",
+                    "",
                 ]
             )
         path = f.name
@@ -104,7 +120,7 @@ class TestBookmarkLoader:
             rows = list(csv.DictReader(f))
 
         assert len(rows) == 3
-        assert rows[0]["link"] == "https://python.org"
+        assert rows[0]["url"] == "https://python.org"
 
     def test_save_by_source_file(self, sample_bookmarks, tmp_path):
         """Test saving bookmarks by source file."""


### PR DESCRIPTION
## Summary
- make CSV the default output format
- allow specifying JSON format with `--format`
- update bookmark loader CSV columns
- update tests for new CSV columns
- document new defaults and format option

## Testing
- `ruff check core/bookmark_loader.py bookmark_enricher.py core/enricher.py tests/test_bookmark_loader.py tests/test_bookmark_importer.py`
- `mypy core/` *(fails: bookmarks-local-ai is not a valid Python package name)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a630d2f883298a10d9277f3e9310