### PR TITLE
Fix ruff errors

### DIFF
--- a/core/backup_manager.py
+++ b/core/backup_manager.py
@@ -4,8 +4,6 @@ Backup and safety utilities for bookmark processing.
 
 import os
 import shutil
-import json
-import time
 from datetime import datetime
 from typing import List, Optional, Dict
 import logging

--- a/core/category_manager.py
+++ b/core/category_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Sequence, Tuple
 
 from .bookmark_loader import BookmarkLoader
 from .models import Bookmark
@@ -195,7 +195,9 @@ class CategoryManager:
                 return False
 
             logger.info(
-                f"Successfully moved {len(bookmarks_to_move)} bookmarks to {target_category}"
+                "Successfully moved %d bookmarks to %s",
+                len(bookmarks_to_move),
+                target_category,
             )
             return True
 
@@ -235,7 +237,8 @@ class CategoryManager:
             return False
 
         print(
-            f"\nFound {len(candidates)} potential matches for '{category_name}' category:\n"
+            "\nFound "
+            f"{len(candidates)} potential matches for '{category_name}' category:\n"
         )
 
         for i, (bookmark, score) in enumerate(candidates, 1):

--- a/core/category_suggester.py
+++ b/core/category_suggester.py
@@ -49,8 +49,6 @@ class CategorySuggester:
 
             # More reasonable cluster size: 3-15 bookmarks per cluster
             min_size = max(3, min(15, len(embeddings) // 50))
-            max_clusters = min(10, len(embeddings) // 20)  # Cap at 10 clusters
-
             clusterer = hdbscan.HDBSCAN(
                 min_cluster_size=min_size,
                 min_samples=max(2, min_size // 2),  # Allow some flexibility
@@ -63,10 +61,12 @@ class CategorySuggester:
             unique_labels.discard(-1)  # Remove noise label
 
             logger.info(
-                f"HDBSCAN: {len(unique_labels)} clusters found with min_cluster_size={min_size}"
+                "HDBSCAN: %s clusters found with min_cluster_size=%s",
+                len(unique_labels),
+                min_size,
             )
 
-            # If we got too few clusters, fall back to k-means for more predictable results
+            # Fall back to k-means if too few clusters
             if len(unique_labels) < 2:
                 logger.info("Too few HDBSCAN clusters, falling back to k-means")
                 raise ValueError("Insufficient clusters")
@@ -107,7 +107,8 @@ class CategorySuggester:
         if existing_names:
             example_names = sorted(list(existing_names))[:5]  # Show up to 5 examples
             style_examples = (
-                f"Follow the existing naming style from these categories: {', '.join(example_names)}. "
+                "Follow the existing naming style from these categories: "
+                f"{', '.join(example_names)}. "
                 "Match their format, length, and style conventions. "
             )
 
@@ -116,8 +117,11 @@ class CategorySuggester:
             "the following bookmarks. "
             + style_examples
             + "You MUST respond with ONLY valid JSON "
-            'in this exact format: {"name":"category-name","description":"description"}\n\n'
-            "Do not include any other text before or after the JSON.\n\n"
+            + (
+                "in this exact format: "
+                '{"name":"category-name","description":"description"}\n\n'
+            )
+            + "Do not include any other text before or after the JSON.\n\n"
             + "\n".join(bullet_lines)
         )
         try:
@@ -237,6 +241,8 @@ class CategorySuggester:
                 break
 
         logger.info(
-            f"Generated {len(suggestions)} category suggestions from {len(sorted_clusters)} clusters"
+            "Generated %d category suggestions from %d clusters",
+            len(suggestions),
+            len(sorted_clusters),
         )
         return suggestions

--- a/core/progress_tracker.py
+++ b/core/progress_tracker.py
@@ -3,7 +3,6 @@ Progress tracking and reporting utilities.
 """
 
 import time
-import sys
 from typing import Optional
 from dataclasses import dataclass
 import logging

--- a/core/vector_store.py
+++ b/core/vector_store.py
@@ -42,7 +42,7 @@ class VectorStore:
         try:
             self.collection = self.client.get_collection(name=self.collection_name)
             logger.info(f"Using existing ChromaDB collection: {self.collection_name}")
-        except:
+        except Exception:
             self.collection = self.client.create_collection(name=self.collection_name)
             logger.info(f"Created new ChromaDB collection: {self.collection_name}")
 

--- a/tests/test_backup_manager_additional.py
+++ b/tests/test_backup_manager_additional.py
@@ -1,6 +1,5 @@
 import os
 import json
-import tempfile
 from core.backup_manager import BackupManager, create_safety_backup
 
 
@@ -34,7 +33,7 @@ def test_get_backup_stats_and_extract(tmp_path):
     manager = BackupManager(backup_dir=str(tmp_path / "bk"))
     # create two backups to ensure stats count >1
     first = manager.create_backup(str(test_file))
-    second = manager.create_backup(str(test_file), "second.backup")
+    manager.create_backup(str(test_file), "second.backup")
     stats = manager.get_backup_stats()
     assert stats["total_backups"] >= 2
     assert stats["total_size_bytes"] > 0

--- a/tests/test_category_manager.py
+++ b/tests/test_category_manager.py
@@ -409,7 +409,6 @@ class TestCategoryManagerIntegration:
 
         # Create CategoryManager with real dependencies
         from core.bookmark_loader import BookmarkLoader
-        from core.vector_store import VectorStore
 
         # Mock just the vector store for this test
         mock_vector_store = Mock()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,11 +2,8 @@
 Tests for configuration management.
 """
 
-import pytest
 import os
 import tempfile
-import yaml
-import json
 from core.config_manager import (
     BookmarkConfig,
     ModelConfig,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,6 @@
 Tests for data models.
 """
 
-import pytest
 from core.models import Bookmark, SimilarBookmark, SearchResult, DuplicateGroup
 
 
@@ -218,7 +217,10 @@ class TestDuplicateGroup:
         bookmark1 = Bookmark(url="https://example.com", title="Short")
         bookmark2 = Bookmark(
             url="https://example.com",
-            title="Very long title that should be truncated because it exceeds fifty characters",
+            title=(
+                "Very long title that should be truncated because it exceeds "
+                "fifty characters"
+            ),
         )
 
         group = DuplicateGroup(

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -2,8 +2,7 @@
 Tests for vector store operations.
 """
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from core.vector_store import VectorStore
 from core.models import Bookmark
 

--- a/tests/test_web_extractor.py
+++ b/tests/test_web_extractor.py
@@ -2,7 +2,6 @@
 Tests for web content extraction.
 """
 
-import pytest
 import requests
 from unittest.mock import Mock, patch
 from core.web_extractor import WebExtractor


### PR DESCRIPTION
## Summary
- resolve various ruff violations across modules and tests
- split long strings and log messages
- remove unused variables and imports
- use explicit exception type in `vector_store`

## Testing
- `ruff check .`
- `black . --check`
- `mypy core`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882b78fcef88329a069a78b11777350